### PR TITLE
Let the user use an Implementation of List.

### DIFF
--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlAdapter.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlAdapter.java
@@ -39,7 +39,7 @@ public class HtmlAdapter<T> {
             }
 
             // Not annotated field - List of annotated type
-            if (selector == null && fieldClass.equals(List.class)) {
+            if (selector == null && List.class.isAssignableFrom(fieldClass)) {
                 selector = getSelectorFromListType(field);
             }
 
@@ -67,7 +67,7 @@ public class HtmlAdapter<T> {
 
     private void addCachedHtmlField(Field field, Selector selector, Class<?> fieldClass) {
         HtmlField<T> htmlField;
-        if (fieldClass.equals(List.class)) {
+        if (List.class.isAssignableFrom(fieldClass)) {
             htmlField = new HtmlListField<>(field, selector);
         } else if (Utils.isSimple(fieldClass)) {
             htmlField = new HtmlSimpleField<>(field, selector);

--- a/jspoon/src/test/java/pl/droidsonroids/jspoon/AdvancedTest.java
+++ b/jspoon/src/test/java/pl/droidsonroids/jspoon/AdvancedTest.java
@@ -168,7 +168,7 @@ public class AdvancedTest {
                   format = "HH:mm dd.MM.yyyy") Date created;
         @Selector("h2") String header;
         @Selector("p") String content;
-        @Selector("li") List<String> tags;
+        @Selector("li") ArrayList<String> tags;
 
         AnnotatedPost() {
             //no-op
@@ -178,7 +178,7 @@ public class AdvancedTest {
             this.created = created;
             this.header = header;
             this.content = content;
-            this.tags = Arrays.asList(tags);
+            this.tags = new ArrayList<>(Arrays.asList(tags));
         }
 
         @Override

--- a/jspoon/src/test/java/pl/droidsonroids/jspoon/SimpleTypesListTest.java
+++ b/jspoon/src/test/java/pl/droidsonroids/jspoon/SimpleTypesListTest.java
@@ -1,5 +1,6 @@
 package pl.droidsonroids.jspoon;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;
@@ -29,31 +30,37 @@ public class SimpleTypesListTest {
 
     private static class BooleanModel {
         @Selector(".boolean") List<Boolean> booleanList;
+        @Selector(".boolean") ArrayList<Boolean> booleanArrayList;
     }
 
     private static class IntModel {
         @Selector(".int") List<Integer> integerList;
+        @Selector(".int") ArrayList<Integer> integerArrayList;
     }
     private static class StringModel {
         @Selector(".string") List<String> stringList;
+        @Selector(".string") ArrayList<String> stringArrayList;
     }
 
     @Test
-    public void booleanList() {
+    public void booleanLists() {
         BooleanModel booleanModel = createObjectFromHtml(BooleanModel.class);
         assertEquals(booleanModel.booleanList, Arrays.asList(true, false, false));
+        assertEquals(booleanModel.booleanArrayList, new ArrayList<>(Arrays.asList(true, false, false)));
     }
 
     @Test
-    public void integerList() {
+    public void integerLists() {
         IntModel intModel = createObjectFromHtml(IntModel.class);
         assertEquals(intModel.integerList, Arrays.asList(-200, 4, 32000));
+        assertEquals(intModel.integerArrayList, new ArrayList<>(Arrays.asList(-200, 4, 32000)));
     }
 
     @Test
-    public void stringList() {
+    public void stringLists() {
         StringModel stringModel = createObjectFromHtml(StringModel.class);
         assertEquals(stringModel.stringList, Arrays.asList("Test1", "", "Test2 ".trim()));
+        assertEquals(stringModel.stringArrayList, new ArrayList<>(Arrays.asList("Test1", "", "Test2 ".trim())));
     }
 
     private <T> T createObjectFromHtml(Class<T> className) {


### PR DESCRIPTION
Hello,

Fixed a crash that occurred when a field of a class which have a selector was not a *List but* an implementation of it like *Arraylist*. In some case like when using the **Realm library** the user have to use a *RealmList*.

A simple way to see this is to replace the type of the posts field in the **BlogPage** class in the sample app from *List* to *ArrayList*.

So now **jspoon** will allow, recognize and return the correct type of a field when it's type is an implantation of *List* or *List* itself.

Thank you for building jspoon :-)