### PR TITLE
Big decimal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ It looks for the first occurrence in HTML and sets its value to a field.
 * `Float`
 * `Double`
 * `Date`
+* `BigDecimal`
 * Jsoup's `Element`
-* Any class with  default contructor
+* Any class with  default constructor
 * `List` (or its superclass/superinterface) of supported type
 
 It can also be used with a class, then you don't need to annotate every field inside it.

--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/Utils.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/Utils.java
@@ -1,5 +1,6 @@
 package pl.droidsonroids.jspoon;
 
+import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
 import org.jsoup.nodes.Element;
@@ -12,6 +13,7 @@ class Utils {
                 clazz.equals(Float.class) || clazz.equals(float.class) ||
                 clazz.equals(Double.class) || clazz.equals(double.class) ||
                 clazz.equals(Boolean.class) || clazz.equals(boolean.class) ||
+                clazz.equals(BigDecimal.class) ||
                 clazz.equals(Element.class) ||
                 clazz.equals(List.class) ||
                 clazz.equals(Date.class) ||

--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/annotation/Selector.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/annotation/Selector.java
@@ -21,8 +21,9 @@ import pl.droidsonroids.jspoon.HtmlAdapter;
  * Long
  * Boolean
  * Date
+ * BigDecimal
  * {@link Element}
- * Any class with default contructor
+ * Any class with default constructor
  * List of supported type
  *
  * It can also be used with a class, then you don't need to annotate every field inside it.

--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/exception/BigDecimalParseException.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/exception/BigDecimalParseException.java
@@ -1,0 +1,11 @@
+package pl.droidsonroids.jspoon.exception;
+
+import java.util.Locale;
+
+public class BigDecimalParseException extends RuntimeException {
+    private static final long serialVersionUID = 3295320880915491873L;
+
+    public BigDecimalParseException(String value, String format, Locale locale) {
+        super(String.format(Locale.ENGLISH, "Cannot parse BigDecimal %s with format: %s and locale: %s.", value, format, locale.toLanguageTag()));
+    }
+}

--- a/jspoon/src/test/java/pl/droidsonroids/jspoon/BigDecimalFormatTest.java
+++ b/jspoon/src/test/java/pl/droidsonroids/jspoon/BigDecimalFormatTest.java
@@ -1,0 +1,49 @@
+package pl.droidsonroids.jspoon;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.text.ParseException;
+import java.util.Locale;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import pl.droidsonroids.jspoon.annotation.Selector;
+import pl.droidsonroids.jspoon.rule.CustomLocaleRule;
+
+public class BigDecimalFormatTest {
+
+    private Jspoon jspoon;
+
+    @Rule
+    public CustomLocaleRule customLocaleRule = new CustomLocaleRule(Locale.US);
+
+    @Before
+    public void setUp() {
+        jspoon = Jspoon.create();
+    }
+
+    private static class Money {
+
+        @Selector(value = "#amount", format = "0,000.00") BigDecimal amount;
+    }
+
+    @Test
+    public void amount() throws ParseException {
+        Money money = createObjectFromHtml(Money.class);
+        DecimalFormat format = new DecimalFormat("0,000.00");
+        format.setParseBigDecimal(true);
+        BigDecimal expected = (BigDecimal) format.parse("50,000.00");
+        assertEquals(money.amount, expected);
+    }
+
+    private <T> T createObjectFromHtml(Class<T> className) {
+        HtmlAdapter<T> htmlAdapter = jspoon.adapter(className);
+        return htmlAdapter.fromHtml("<div>"
+            + "<span id='amount'>50,000.00</span>"
+            + "</div>");
+    }
+}


### PR DESCRIPTION
Hi! 

This PR adds support for transforming `BigDecimal` types. Uses the same `format` property from the `@Selector` to create a parser for the values.

Also, I bumped the version to 1.1.0.