### PR TITLE
Jsoup parse input stream

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-POM_VERSION=1.0.1
+POM_VERSION=1.1.0
 POM_GROUP=pl.droidsonroids
 POM_ARTIFACT_ID=jspoon
 POM_DESCRIPTION=Annotation based HTML to Java parser

--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlAdapter.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlAdapter.java
@@ -1,14 +1,21 @@
 package pl.droidsonroids.jspoon;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
+
 import pl.droidsonroids.jspoon.annotation.Selector;
 import pl.droidsonroids.jspoon.exception.ConstrucorNotFoundException;
 import pl.droidsonroids.jspoon.exception.ObjectCreationException;
@@ -57,6 +64,51 @@ public class HtmlAdapter<T> {
     public T fromHtml(String htmlContent) {
         Element pageRoot = Jsoup.parse(htmlContent);
         return loadFromNode(pageRoot);
+    }
+
+    /**
+     * Converts the provided {@code InputStream} to a {@code T} object.
+     * <p>
+     * Does not close the {@code InputStream}.
+     *
+     * @param inputStream InputStream with HTML content
+     * @return Created object of type {@code T}
+     * @throws IOException If I/O error occurs while reading the {@code InputStream}
+     */
+    public T fromInputStream(InputStream inputStream) throws IOException {
+        return fromInputStream(inputStream, null);
+    }
+
+    /**
+     * Converts the provided {@code inputStream} to a {@code T} object.
+     * <p>
+     * Does not close the {@code InputStream}.
+     *
+     * @param inputStream InputStream with HTML content
+     * @param baseUrl The URL where the HTML was retrieved from, to resolve relative links against.
+     * @return Created object of type {@code T}
+     * @throws IOException If I/O error occurs while reading the {@code InputStream}
+     */
+    public T fromInputStream(InputStream inputStream, URL baseUrl) throws IOException {
+        return fromInputStream(inputStream, null, baseUrl);
+    }
+
+    /**
+     * Converts the provided {@code inputStream} to a {@code T} object.
+     * <p>
+     * Does not close the {@code InputStream}.
+     *
+     * @param inputStream InputStream with HTML content
+     * @param charset Charset to use
+     * @param baseUrl The URL where the HTML was retrieved from, to resolve relative links against.
+     * @return Created object of type {@code T}
+     * @throws IOException If I/O error occurs while reading the {@code InputStream}
+     */
+    public T fromInputStream(InputStream inputStream, Charset charset, URL baseUrl) throws IOException {
+        String urlToUse = baseUrl != null ? baseUrl.toString() : null;
+        String charsetToUse = charset != null ? charset.name() : null;
+        Element root = Jsoup.parse(inputStream, charsetToUse, urlToUse);
+        return loadFromNode(root);
     }
 
     private Selector getSelectorFromListType(Field field) {

--- a/jspoon/src/test/java/pl/droidsonroids/jspoon/HtmlAdapterTest.java
+++ b/jspoon/src/test/java/pl/droidsonroids/jspoon/HtmlAdapterTest.java
@@ -1,0 +1,47 @@
+package pl.droidsonroids.jspoon;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import pl.droidsonroids.jspoon.annotation.Selector;
+
+public class HtmlAdapterTest {
+
+    private static final String HTML_CONTENT = "<div>"
+        + "<span id='firstname'>John</span>"
+        + "<span id='lastname'>Doe</span>"
+        + "</div>";
+
+    private static class Profile {
+
+        @Selector(value = "#firstname") String firstname;
+        @Selector(value = "#lastname") String lastname;
+    }
+
+    private Jspoon jspoon;
+
+    @Before
+    public void setUp() {
+        jspoon = Jspoon.create();
+    }
+
+    @Test
+    public void testFromInputStream() throws IOException {
+        HtmlAdapter<Profile> adapter = jspoon.adapter(Profile.class);
+        URL baseUrl = URI.create( "http://localhost/profile" ).toURL();
+        try (ByteArrayInputStream inputStream
+            = new ByteArrayInputStream(HTML_CONTENT.getBytes())) {
+
+            Profile profile = adapter.fromInputStream(inputStream, baseUrl);
+            assertEquals("John", profile.firstname);
+            assertEquals("Doe", profile.lastname);
+        }
+    }
+}

--- a/retrofit-converter-jspoon/src/main/java/pl/droidsonroids/retrofit2/JspoonConverterFactory.java
+++ b/retrofit-converter-jspoon/src/main/java/pl/droidsonroids/retrofit2/JspoonConverterFactory.java
@@ -24,6 +24,7 @@ public final class JspoonConverterFactory extends Converter.Factory {
 
     @Override
     public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
-        return new JspoonResponseBodyConverter<>(jspoon.adapter((Class<?>) type));
+        return new JspoonResponseBodyConverter<>(retrofit.baseUrl(),
+            jspoon.adapter((Class<?>) type));
     }
 }

--- a/retrofit-converter-jspoon/src/main/java/pl/droidsonroids/retrofit2/JspoonResponseBodyConverter.java
+++ b/retrofit-converter-jspoon/src/main/java/pl/droidsonroids/retrofit2/JspoonResponseBodyConverter.java
@@ -1,19 +1,38 @@
 package pl.droidsonroids.retrofit2;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
 import okhttp3.ResponseBody;
 import pl.droidsonroids.jspoon.HtmlAdapter;
 import retrofit2.Converter;
 
 class JspoonResponseBodyConverter<T> implements Converter<ResponseBody, T> {
-    private HtmlAdapter<T> htmlAdapter;
 
-    JspoonResponseBodyConverter(HtmlAdapter<T> htmlAdapter) {
+    private final HttpUrl httpUrl;
+    private final HtmlAdapter<T> htmlAdapter;
+
+    JspoonResponseBodyConverter(HttpUrl httpUrl, HtmlAdapter<T> htmlAdapter) {
+        this.httpUrl = httpUrl;
         this.htmlAdapter = htmlAdapter;
     }
 
     @Override
     public T convert(ResponseBody responseBody) throws IOException {
-        return htmlAdapter.fromHtml(responseBody.string());
+        Charset charset = null;
+        MediaType mediaType = responseBody.contentType();
+        if (mediaType != null)
+            charset = mediaType.charset();
+
+        InputStream is = responseBody.byteStream();
+        try {
+            return htmlAdapter.fromInputStream(is, charset, httpUrl.url());
+        } finally {
+            is.close();
+        }
     }
 }


### PR DESCRIPTION
Hi! 

This PR improves the previous implementation by removing the intermediate string via `ResponseBody#string`, by directly parsing its `InputStream`. This reduces the memory footprint because the entire document string is not loaded in the memory. Forwarded the baseUrl to Jsoup so that it can resolve relative links.

Also, I bumped the version to 1.1.0.