### PR TITLE
 Skip services that're unsupported by Jspoon

### DIFF
--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlAdapter.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlAdapter.java
@@ -17,7 +17,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 
 import pl.droidsonroids.jspoon.annotation.Selector;
-import pl.droidsonroids.jspoon.exception.ConstrucorNotFoundException;
+import pl.droidsonroids.jspoon.exception.ConstructorNotFoundException;
 import pl.droidsonroids.jspoon.exception.EmptySelectorException;
 import pl.droidsonroids.jspoon.exception.ObjectCreationException;
 
@@ -148,7 +148,7 @@ public class HtmlAdapter<T> {
         try {
             constructor = clazz.getDeclaredConstructor();
         } catch (NoSuchMethodException e) {
-            throw new ConstrucorNotFoundException(clazz.getSimpleName());
+            throw new ConstructorNotFoundException(clazz.getSimpleName());
         }
         constructor.setAccessible(true);
         try {

--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlAdapter.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlAdapter.java
@@ -18,6 +18,7 @@ import org.jsoup.nodes.Element;
 
 import pl.droidsonroids.jspoon.annotation.Selector;
 import pl.droidsonroids.jspoon.exception.ConstrucorNotFoundException;
+import pl.droidsonroids.jspoon.exception.EmptySelectorException;
 import pl.droidsonroids.jspoon.exception.ObjectCreationException;
 
 /**
@@ -53,6 +54,10 @@ public class HtmlAdapter<T> {
             if (selector != null) {
                 addCachedHtmlField(field, selector, fieldClass);
             }
+        }
+
+        if (htmlFieldCache.isEmpty()) {
+            throw new EmptySelectorException( clazz );
         }
     }
 

--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/exception/ConstrucorNotFoundException.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/exception/ConstrucorNotFoundException.java
@@ -2,6 +2,10 @@ package pl.droidsonroids.jspoon.exception;
 
 import java.util.Locale;
 
+/**
+ * @deprecated Use {@linkplain ConstructorNotFoundException}. This class is kept for backwards compatibility.
+ */
+@Deprecated
 public class ConstrucorNotFoundException extends RuntimeException {
     private static final long serialVersionUID = -3960224299384172909L;
 

--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/exception/ConstructorNotFoundException.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/exception/ConstructorNotFoundException.java
@@ -1,0 +1,9 @@
+package pl.droidsonroids.jspoon.exception;
+
+public class ConstructorNotFoundException extends ConstrucorNotFoundException {
+    private static final long serialVersionUID = -9106503492095273112L;
+
+    public ConstructorNotFoundException(String className) {
+        super(className);
+    }
+}

--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/exception/EmptySelectorException.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/exception/EmptySelectorException.java
@@ -1,0 +1,12 @@
+package pl.droidsonroids.jspoon.exception;
+
+/**
+ * Exception thrown when type doesn't contain a field, or is not annotated with {@code @Selector}
+ */
+public class EmptySelectorException extends RuntimeException {
+
+    public EmptySelectorException(Class type) {
+        super(String.format("Unable to find @Selector on type '%s', or its fields. "
+            + "Is this type intended for parsing HTML?", type));
+    }
+}

--- a/retrofit-converter-jspoon/build.gradle
+++ b/retrofit-converter-jspoon/build.gradle
@@ -7,7 +7,12 @@ plugins {
 
 dependencies {
     compile 'com.squareup.retrofit2:retrofit:2.3.0'
-    compile "pl.droidsonroids:jspoon:${POM_VERSION}"
+    compile project(":jspoon")
+
+    testCompile 'junit:junit:4.12'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.9.1'
+    testCompile 'org.mockito:mockito-core:2.13.0'
+
 }
 
 group = POM_RETROFIT_GROUP

--- a/retrofit-converter-jspoon/build.gradle
+++ b/retrofit-converter-jspoon/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 dependencies {
     compile 'com.squareup.retrofit2:retrofit:2.3.0'
-    compile project(":jspoon")
+    compile "pl.droidsonroids:jspoon:${POM_VERSION}"
 
     testCompile 'junit:junit:4.12'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.9.1'

--- a/retrofit-converter-jspoon/src/main/java/pl/droidsonroids/retrofit2/JspoonConverterFactory.java
+++ b/retrofit-converter-jspoon/src/main/java/pl/droidsonroids/retrofit2/JspoonConverterFactory.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import okhttp3.ResponseBody;
 import pl.droidsonroids.jspoon.Jspoon;
+import pl.droidsonroids.jspoon.exception.EmptySelectorException;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 
@@ -24,7 +25,12 @@ public final class JspoonConverterFactory extends Converter.Factory {
 
     @Override
     public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations, Retrofit retrofit) {
-        return new JspoonResponseBodyConverter<>(retrofit.baseUrl(),
+
+        try {
+            return new JspoonResponseBodyConverter<>(retrofit.baseUrl(),
             jspoon.adapter((Class<?>) type));
+        } catch (EmptySelectorException ex) {
+            return null; // Let retrofit choose another converter
+        }
     }
 }

--- a/retrofit-converter-jspoon/src/test/java/pl/droidsonroids/retrofit2/JspoonConverterFactoryTest.java
+++ b/retrofit-converter-jspoon/src/test/java/pl/droidsonroids/retrofit2/JspoonConverterFactoryTest.java
@@ -1,0 +1,73 @@
+package pl.droidsonroids.retrofit2;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import org.junit.Test;
+
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import retrofit2.Call;
+import retrofit2.Converter;
+import retrofit2.Converter.Factory;
+import retrofit2.Retrofit;
+import retrofit2.Retrofit.Builder;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+
+public class JspoonConverterFactoryTest {
+
+    private interface NonScrapingService {
+
+        @GET("/item/{id}")
+        Call<Item> getItem(@Path("id") String id);
+    }
+
+    private class Item {
+
+        private String id;
+        private String name;
+
+        private Item(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
+    @Test
+    public void testJspoonConverterAllowsRetrofitToChooseAnotherConverter() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody("Ahoy matey!"));
+
+        Converter mockConverter = mock(Converter.class);
+        when(mockConverter.convert(any(ResponseBody.class)))
+            .thenReturn(new Item("1", "Item 1"));
+
+        Factory mockConverterFactory = mock(Factory.class);
+        when(mockConverterFactory.responseBodyConverter(
+            any(Type.class),
+            any(Annotation[].class),
+            any(Retrofit.class))).thenReturn(mockConverter);
+
+        NonScrapingService service = new Builder()
+            .baseUrl(server.url("/"))
+            .addConverterFactory(JspoonConverterFactory.create())
+            .addConverterFactory(mockConverterFactory)
+            .build()
+            .create(NonScrapingService.class);
+        Item item = service.getItem("1").execute().body();
+        assertEquals(item.id, "1");
+        assertEquals(item.name, "Item 1");
+
+        verify(mockConverter, atLeastOnce()).convert(any(ResponseBody.class));
+    }
+}


### PR DESCRIPTION
Hi again!

This PR updates the factory such that it allows retrofit to choose another converter when the return types don't contain an element annotated with `@Selector` (i.e.: not meant to be parsed by jspoon).

I encountered this when I was trying to use the jspoon converter with the jackson converter. Jspoon was trying to build an adapter even for types (in my case, to-be-serialized-JSON) that it couldn't handle.

---
Also tried to fix the typo in the `ConstrucorNotFoundException` by adding a correctly-named subclass. I first renamed the file, but noticed it was a public exception so I kept backwards compatibility.