### PR TITLE
Recognize default values assigned to annotated field

### DIFF
--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlListField.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlListField.java
@@ -22,14 +22,14 @@ class HtmlListField<T> extends HtmlField<T> {
         Type type = ((ParameterizedType) genericType).getActualTypeArguments()[0];
         Class<?> listClass = (Class<?>) type;
 
-        setFieldOrThrow(field, newInstance, populateList(jspoon, nodes, listClass));
+        setFieldOrThrow(field, newInstance, populateList(jspoon, nodes, listClass, newInstance));
     }
 
-    private <V> List<V> populateList(Jspoon jspoon, Elements nodes, Class<V> listClazz) {
+    private <V> List<V> populateList(Jspoon jspoon, Elements nodes, Class<V> listClazz, T newInstance) {
         List<V> newInstanceList = new ArrayList<>();
         if (Utils.isSimple(listClazz)) {
             for (Element node : nodes) {
-                newInstanceList.add(instanceForNode(node, listClazz));
+                newInstanceList.add(instanceForNode(node, listClazz, newInstance));
             }
         } else {
             HtmlAdapter<V> htmlAdapter = jspoon.adapter(listClazz);
@@ -37,6 +37,10 @@ class HtmlListField<T> extends HtmlField<T> {
                 newInstanceList.add(htmlAdapter.loadFromNode(node));
             }
         }
+
+        if (newInstanceList.isEmpty()) // See if there's already a default value
+            newInstanceList = getFieldValue(newInstance, newInstanceList);
+
         return newInstanceList;
     }
 }

--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlSimpleField.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlSimpleField.java
@@ -12,6 +12,6 @@ class HtmlSimpleField<T> extends HtmlField<T> {
     @Override
     public void setValue(Jspoon jspoon, Element node, T newInstance) {
         Element selectedNode = selectChild(node);
-        setFieldOrThrow(field, newInstance, instanceForNode(selectedNode, field.getType()));
+        setFieldOrThrow(field, newInstance, instanceForNode(selectedNode, field.getType(), newInstance));
     }
 }

--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/Utils.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/Utils.java
@@ -19,4 +19,25 @@ class Utils {
                 clazz.equals(Date.class) ||
                 clazz.equals(Element.class);
     }
+
+    static Object getDefaultValueForType(Class clazz) {
+        if (!clazz.isPrimitive())
+            return null;
+        if (clazz.equals(boolean.class))
+            return false;
+        if (clazz.equals(int.class)
+            || clazz.equals(byte.class)
+            || clazz.equals(short.class))
+            return 0;
+        if (clazz.equals(long.class))
+            return 0L;
+        if (clazz.equals(float.class))
+            return 0F;
+        if (clazz.equals(double.class))
+            return 0D;
+        if (clazz.equals(char.class))
+            return '\u0000';
+
+        throw new AssertionError("Missed primitive type: " + clazz);
+    }
 }

--- a/jspoon/src/test/java/pl/droidsonroids/jspoon/DefaultValueTest.java
+++ b/jspoon/src/test/java/pl/droidsonroids/jspoon/DefaultValueTest.java
@@ -6,6 +6,9 @@ import pl.droidsonroids.jspoon.annotation.Selector;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class DefaultValueTest {
     private Jspoon jspoon;
 
@@ -15,15 +18,45 @@ public class DefaultValueTest {
     }
 
     private static class Model {
-        @Selector(value = "span", defValue = "NO_VALUE") String text;
-        @Selector(value = "p", defValue = "-100") int number;
+        @Selector(value = "span.text", defValue = "NO_VALUE") String text;
+        @Selector(value = "span.number", defValue = "-100") int number;
+        @Selector(value = "span.bool", defValue = "true") boolean bool;
+        @Selector(value = "ul.list", defValue = "NO_VALUE") List<String> list;
+
+        @Selector(value = "span.another-text") String anotherText = "I have value";
+        @Selector(value = "span.another-number") int anotherNumber = /* over */ 9000;
+        @Selector(value = "span.bool") boolean anotherBool = true;
+        @Selector(value = "ul.another-list") List<String> anotherList;
+        @Selector(value = "div.another-submodel") SubModel anotherSubmodel = SubModel.FAKE;
+
+        public Model() {
+            anotherList = new ArrayList<>();
+            anotherList.add("hiding");
+        }
+    }
+
+    private static class SubModel {
+
+        static final SubModel FAKE = new SubModel();
+
+        @Selector(value = "p#name") String name = "fake";
     }
 
     @Test
     public void defaultValueTest() {
         HtmlAdapter<Model> htmlAdapter = jspoon.adapter(Model.class);
         Model model = htmlAdapter.fromHtml("<div></div>");
-        assertEquals(model.text, "NO_VALUE");
-        assertEquals(model.number, -100);
+        assertEquals("NO_VALUE", model.text);
+        assertEquals(-100, model.number);
+        assertEquals(true, model.bool);
+        assertEquals(new ArrayList<String>(), model.list);
+
+        assertEquals("I have value", model.anotherText);
+        assertEquals(9000, model.anotherNumber);
+        assertEquals(true, model.anotherBool);
+        List<String> expected = new ArrayList<>();
+        expected.add("hiding");
+        assertEquals(expected, model.anotherList);
+        assertEquals(SubModel.FAKE, model.anotherSubmodel);
     }
 }


### PR DESCRIPTION
Instead of readily relying on the @Selector#defValue right away, this commit ensures that the assigned value at compile-time is checked first, before deciding to use the default value from the annotation.

Addresses to #28 .

/cc @cr3ativ3 @burnoo 