### PR TITLE
Possibility to default to value initialy set on field

### DIFF
--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlField.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlField.java
@@ -11,8 +11,10 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+
 import pl.droidsonroids.jspoon.annotation.Selector;
 import pl.droidsonroids.jspoon.exception.BigDecimalParseException;
 import pl.droidsonroids.jspoon.exception.DateParseException;
@@ -67,6 +69,9 @@ abstract class HtmlField<T> {
     }
 
     static void setFieldOrThrow(Field field, Object newInstance, Object value) {
+        if (value == null || Selector.NO_VALUE.equals(value)){
+            return;
+        }
         try {
             field.setAccessible(true);
             field.set(newInstance, value);
@@ -134,7 +139,9 @@ abstract class HtmlField<T> {
             }
         }
 
-        return (U) value;
+        // unsupported field type
+        // or String field but selected Element does not exist and no set defValue
+        return null;
     }
 
     private <U> String getValue(Element node, Class<U> clazz) {
@@ -144,6 +151,7 @@ abstract class HtmlField<T> {
         String value;
         switch (attribute) {
             case "":
+            case "text":
                 value = node.text();
                 break;
             case "html":

--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/annotation/Selector.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/annotation/Selector.java
@@ -35,13 +35,14 @@ import pl.droidsonroids.jspoon.HtmlAdapter;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.FIELD })
 public @interface Selector {
-    String NO_VALUE = "NO_VALUE";
+
+    static final String NO_VALUE = "NO_VALUE";
 
     /** @return Css query */
     String value();
 
     /** @return Attribute or property of selected field. "text" is default. Also "html"/"innerHtml" or "outerHtml" is supported. */
-    String attr() default "";
+    String attr() default "text";
 
     /** @return Regex for numbers and String, date format for Date. */
     String format() default NO_VALUE;

--- a/jspoon/src/test/java/pl/droidsonroids/jspoon/AttributeTest.java
+++ b/jspoon/src/test/java/pl/droidsonroids/jspoon/AttributeTest.java
@@ -1,10 +1,11 @@
 package pl.droidsonroids.jspoon;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
-import pl.droidsonroids.jspoon.annotation.Selector;
 
-import static org.junit.Assert.assertEquals;
+import pl.droidsonroids.jspoon.annotation.Selector;
 
 public class AttributeTest {
     private final static String HTML_CONTENT = "<img "
@@ -30,6 +31,9 @@ public class AttributeTest {
 
     private static class HtmlAttributesModel {
         @Selector("div") String text;
+        //"default" by javadocs attr value should have the same result as no attr value above
+        @Selector(value = "div", attr = "text") String text2;
+
         @Selector(value = "div", attr = "html") String html;
         @Selector(value = "div", attr = "innerHtml") String innerHtml;
         @Selector(value = "div", attr = "outerHtml") String outerHtml;
@@ -49,6 +53,7 @@ public class AttributeTest {
     public void htmlAttributes() {
         HtmlAttributesModel htmlAttributesModel = createObjectFromHtml(HtmlAttributesModel.class);
         assertEquals(htmlAttributesModel.text, "test");
+        assertEquals(htmlAttributesModel.text2, "test");
         assertEquals(htmlAttributesModel.html, "<p>test</p>");
         assertEquals(htmlAttributesModel.innerHtml, "<p>test</p>");
         assertEquals(htmlAttributesModel.outerHtml.replaceAll("[\n ]", ""), "<div><p>test</p></div>");

--- a/jspoon/src/test/java/pl/droidsonroids/jspoon/DefaultValueTest.java
+++ b/jspoon/src/test/java/pl/droidsonroids/jspoon/DefaultValueTest.java
@@ -1,10 +1,12 @@
 package pl.droidsonroids.jspoon;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.junit.Before;
 import org.junit.Test;
-import pl.droidsonroids.jspoon.annotation.Selector;
 
-import static org.junit.Assert.assertEquals;
+import pl.droidsonroids.jspoon.annotation.Selector;
 
 public class DefaultValueTest {
     private Jspoon jspoon;
@@ -15,15 +17,23 @@ public class DefaultValueTest {
     }
 
     private static class Model {
-        @Selector(value = "span", defValue = "NO_VALUE") String text;
+        @Selector(value = "span", defValue = "DEFAULT_VALUE") String text;
         @Selector(value = "p", defValue = "-100") int number;
+
+        @Selector(value = "span", defValue = "hello") String text2 = "world";
+        @Selector(value = "span") String text3 = "helloworld";
+        @Selector(value = "span") String text4;
     }
 
     @Test
     public void defaultValueTest() {
         HtmlAdapter<Model> htmlAdapter = jspoon.adapter(Model.class);
         Model model = htmlAdapter.fromHtml("<div></div>");
-        assertEquals(model.text, "NO_VALUE");
-        assertEquals(model.number, -100);
+        //assertEquals("NO_VALUE", model.text);  // bad test case when set defValue is the same result as unset defValue
+        assertEquals("DEFAULT_VALUE", model.text); // since defValue explicitly defined
+        assertEquals("hello", model.text2); // defValue takes precedent as its whatever would be parsed from Element
+        assertEquals("helloworld", model.text3); // no defValue, let's leave whatever is set
+        assertNull(model.text4); // should not be set to anything silently if developer did not set a defValue
+        assertEquals(-100, model.number);
     }
 }

--- a/jspoon/src/test/java/pl/droidsonroids/jspoon/DefaultValueTest.java
+++ b/jspoon/src/test/java/pl/droidsonroids/jspoon/DefaultValueTest.java
@@ -29,7 +29,6 @@ public class DefaultValueTest {
     public void defaultValueTest() {
         HtmlAdapter<Model> htmlAdapter = jspoon.adapter(Model.class);
         Model model = htmlAdapter.fromHtml("<div></div>");
-        //assertEquals("NO_VALUE", model.text);  // bad test case when set defValue is the same result as unset defValue
         assertEquals("DEFAULT_VALUE", model.text); // since defValue explicitly defined
         assertEquals("hello", model.text2); // defValue takes precedent as its whatever would be parsed from Element
         assertEquals("helloworld", model.text3); // no defValue, let's leave whatever is set


### PR DESCRIPTION
defValue should be a fallback for css selector parse result, a default
value for any type of field can also be set by initializg that field to
whatever. In my opinion an acceptable resolution to #28 
Also fixed default attribute parsing.

Consider as instead of #34 