### PR TITLE
Downgrade jsoup 1.10.3

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -6,7 +6,7 @@ ext {
                 gradle       : '3.0.1',
                 support      : '27.0.2',
                 constraint   : '1.0.2',
-                jsoup        : '1.11.2',
+                jsoup        : '1.10.3',
                 junit        : '4.12',
                 retrofit     : '2.3.0',
                 mockwebserver: '3.9.1',


### PR DESCRIPTION
Should downgrade to jsoup 1.10.3 until issues jhy/jsoup#992 and
jhy/jsoup#990 are fixed with 1.11.3

Reported by jspoon user at #52  