### PR TITLE
Change compile to api/implementation in Gradle files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ jspoon is a Java library that provides parsing HTML into Java objects basing on 
 Insert the following dependency into your project's `build.gradle` file:
 ```gradle
 dependencies {
-    compile 'pl.droidsonroids:jspoon:1.3.0'
+    implementation 'pl.droidsonroids:jspoon:1.3.0'
 }
 ```
 ## Usage

--- a/advanced-example/build.gradle
+++ b/advanced-example/build.gradle
@@ -15,10 +15,10 @@ sourceSets {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
-
     implementation project(":jspoon")
     implementation project(":retrofit-converter-jspoon")
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
     implementation "com.squareup.retrofit2:adapter-rxjava2:$versions.retrofit"
 
     testImplementation "junit:junit:$versions.junit"

--- a/android-example/build.gradle
+++ b/android-example/build.gradle
@@ -26,8 +26,8 @@ repositories {
 }
 
 dependencies {
-    compile "com.android.support:appcompat-v7:$versions.support"
-    compile "com.android.support.constraint:constraint-layout:$versions.constraint"
+    implementation project(":jspoon")
 
-    compile project(":jspoon")
+    implementation "com.android.support:appcompat-v7:$versions.support"
+    implementation "com.android.support.constraint:constraint-layout:$versions.constraint"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:$versions.gradle"
+        classpath "com.android.tools.build:gradle:$versions.androidPlugin"
     }
 }
 

--- a/jspoon/build.gradle
+++ b/jspoon/build.gradle
@@ -1,13 +1,13 @@
 plugins {
-    id 'java'
+    id 'java-library'
     id 'maven-publish'
     id 'signing'
     id 'com.bmuschko.nexus' version "2.3.1"
 }
 
 dependencies {
-    compile "org.jsoup:jsoup:$versions.jsoup"
-    testCompile "junit:junit:$versions.junit"
+    api "org.jsoup:jsoup:$versions.jsoup"
+    testImplementation "junit:junit:$versions.junit"
 }
 
 group = POM_GROUP

--- a/retrofit-converter-jspoon/build.gradle
+++ b/retrofit-converter-jspoon/build.gradle
@@ -1,17 +1,17 @@
 plugins {
-    id 'java'
+    id 'java-library'
     id 'maven-publish'
     id 'signing'
     id 'com.bmuschko.nexus' version '2.3.1'
 }
 
 dependencies {
-    compile "com.squareup.retrofit2:retrofit:$versions.retrofit"
-    compile "pl.droidsonroids:jspoon:${POM_VERSION}"
+    api "com.squareup.retrofit2:retrofit:$versions.retrofit"
+    api "pl.droidsonroids:jspoon:${POM_VERSION}"
 
-    testCompile "junit:junit:$versions.junit"
-    testCompile "com.squareup.okhttp3:mockwebserver:$versions.mockwebserver"
-    testCompile "org.mockito:mockito-core:$versions.mockito"
+    testImplementation "junit:junit:$versions.junit"
+    testImplementation "com.squareup.okhttp3:mockwebserver:$versions.mockwebserver"
+    testImplementation "org.mockito:mockito-core:$versions.mockito"
 }
 
 group = POM_RETROFIT_GROUP

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,14 +1,16 @@
 ext {
-    versions = [kotlin       : '1.2.21',
-                sdkVersion   : 27,
-                minSdkVersion: 23,
-                buildTools   : '27.0.3',
-                gradle       : '3.0.1',
-                support      : '27.0.2',
-                constraint   : '1.0.2',
-                jsoup        : '1.10.3',
-                junit        : '4.12',
-                retrofit     : '2.3.0',
-                mockwebserver: '3.9.1',
-                mockito      : '2.13.0']
+    versions = [
+            minSdkVersion: 23,
+            sdkVersion   : 27,
+            androidPlugin: '3.1.3',
+            buildTools   : '27.0.3',
+            constraint   : '1.0.2',
+            jsoup        : '1.10.3',
+            junit        : '4.12',
+            kotlin       : '1.2.21',
+            mockito      : '2.13.0',
+            mockwebserver: '3.9.1',
+            retrofit     : '2.3.0',
+            support      : '27.0.2'
+    ]
 }


### PR DESCRIPTION
Replaced `compile` with `api` in both library `build.gradle` files for backwards compatibility.