### PR TITLE
Use default value on no match regardless of ElementConverter presence

### DIFF
--- a/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlFieldWithConverter.java
+++ b/jspoon/src/main/java/pl/droidsonroids/jspoon/HtmlFieldWithConverter.java
@@ -18,8 +18,10 @@ class HtmlFieldWithConverter<T> extends HtmlField<T> {
     @Override
     public void setValue(Jspoon jspoon, Element node, T newInstance) {
         Element selectedNode = selectChild(node);
-        Selector selectorAnnotation = spec.getSelectorAnnotation();
-        Object converted = converter.convert(selectedNode, selectorAnnotation);
-        setFieldOrThrow(field, newInstance, converted);
+        if (selectedNode != null) {
+            Selector selectorAnnotation = spec.getSelectorAnnotation();
+            Object converted = converter.convert(selectedNode, selectorAnnotation);
+            setFieldOrThrow(field, newInstance, converted);
+        }
     }
 }

--- a/jspoon/src/test/java/pl/droidsonroids/jspoon/ConverterTest.java
+++ b/jspoon/src/test/java/pl/droidsonroids/jspoon/ConverterTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import pl.droidsonroids.jspoon.annotation.Selector;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class ConverterTest {
 
@@ -25,6 +26,9 @@ public class ConverterTest {
 
         @Selector(value="#today-weather", converter=WeatherConverter.class)
         Weather weather;
+
+        @Selector(value="#tomorrow-weather", converter=WeatherConverter.class)
+        Weather tomorrowsWeather;
     }
 
     private enum DayOfWeek {
@@ -74,6 +78,7 @@ public class ConverterTest {
 
         assertEquals(weatherReport.dayOfWeek, DayOfWeek.SATURDAY);
         assertEquals(weatherReport.weather.condition, "sunny");
+        assertNull(weatherReport.tomorrowsWeather);
     }
 
 }


### PR DESCRIPTION
Closes #72.

When no match occurs, Jspoon should use the default value given by the user instead of passing `null` to the `node` of `ElementConverter`. `ElementConverter` shouldn't receive `null` as the Javadoc of `Selector#converter` states that the converter should only be used for matched (i.e. non-null) elements:

https://github.com/DroidsOnRoids/jspoon/blob/2159364d151d9947ff0b3a04d07f8f703e546f9c/jspoon/src/main/java/pl/droidsonroids/jspoon/annotation/Selector.java#L66-L68
